### PR TITLE
Simplify gem install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Igor Ajdisek <igor@3fs.si>
 
 RUN sudo apt-get install -y puppet
 
-RUN sudo gem install --no-rdoc --no-ri librarian-puppet && \
-    sudo gem install --no-rdoc --no-ri puppet-lint && \
-    sudo gem install --no-rdoc --no-ri puppet-lint-trailing_comma-check
+RUN sudo gem install --no-rdoc --no-ri \
+        librarian-puppet \
+        puppet-lint \
+        puppet-lint-trailing_comma-check


### PR DESCRIPTION
`gem install` can install several gems by simply listing them, hence
removing the need to invoke the command multiple times.
